### PR TITLE
Detonating a nuke restores access to neighbouring tiles

### DIFF
--- a/src/script.lua.j2
+++ b/src/script.lua.j2
@@ -18,6 +18,9 @@ features = {{ features | to_lua }}
 
 {% include 'src/scripts/place_ruins_at_destroyed_city.lua' %}
 {% include 'src/scripts/add_random_terrain_labels_to_map.lua' %}
+{% if features.inaccessibleClimates.enabled -%}
+    {% include 'src/scripts/inaccessible_climates.lua' %}
+{%- endif -%}
 {% if features.invisiblePortals.enabled -%}
     {% include 'src/scripts/invisible_portals.lua' %}
 {%- endif -%}

--- a/src/scripts/inaccessible_climates.lua
+++ b/src/scripts/inaccessible_climates.lua
@@ -1,0 +1,14 @@
+-- Restore inaccessible tiles adjacent to nuclear explosions
+function inaccessible_climates_nuke_exploded(tile, player)
+  local inaccessible = "Inaccessible "
+  for adj_tile in tile:square_iterate(1) do
+    local terrain = adj_tile.terrain:rule_name()
+    if terrain:sub(1, #inaccessible) == inaccessible then
+      local accessible = terrain:sub(#inaccessible + 1)
+      adj_tile:change_terrain(find.terrain(accessible))
+    end
+  end
+end
+
+signal.connect("nuke_exploded", "inaccessible_climates_nuke_exploded")
+

--- a/src/terrain.ruleset.j2
+++ b/src/terrain.ruleset.j2
@@ -951,9 +951,9 @@ clean_fallout_time   = 3
 animal               = "None"
 {%- if inaccessibleClimates %}
 warmer_wetter_result = "Inaccessible Lake"
-warmer_drier_result  = "Inaccessible Lake"
-cooler_wetter_result = "Inaccessible Lake"
-cooler_drier_result  = "Inaccessible Lake"
+warmer_drier_result  = "Inaccessible Swamp"
+cooler_wetter_result = "Inaccessible Glacier"
+cooler_drier_result  = "Inaccessible Tundra"
 {%- else %}
 warmer_wetter_result = "no"
 warmer_drier_result  = "Swamp"
@@ -1005,9 +1005,9 @@ clean_fallout_time   = 3
 animal               = "None"
 {%- if inaccessibleClimates %}
 warmer_wetter_result = "Inaccessible Ocean"
-warmer_drier_result  = "Inaccessible Ocean"
-cooler_wetter_result = "Inaccessible Ocean"
-cooler_drier_result  = "Inaccessible Ocean"
+warmer_drier_result  = "Inaccessible Swamp"
+cooler_wetter_result = "Inaccessible Glacier"
+cooler_drier_result  = "Inaccessible Glacier"
 {%- else %}
 warmer_wetter_result = "no"
 warmer_drier_result  = "Swamp"
@@ -1113,8 +1113,8 @@ clean_pollution_time = 3
 clean_fallout_time   = 3
 animal               = "None"
 {%- if inaccessibleClimates %}
-warmer_wetter_result = "Inaccessible Glacier"
-warmer_drier_result  = "Inaccessible Glacier"
+warmer_wetter_result = "Inaccessible Tundra"
+warmer_drier_result  = "Inaccessible Tundra"
 cooler_wetter_result = "Inaccessible Glacier"
 cooler_drier_result  = "Inaccessible Glacier"
 {%- else %}
@@ -1169,9 +1169,9 @@ clean_pollution_time = 3
 clean_fallout_time   = 3
 animal               = "None"
 {%- if inaccessibleClimates %}
-warmer_wetter_result = "Inaccessible Desert"
+warmer_wetter_result = "Inaccessible Plains"
 warmer_drier_result  = "Inaccessible Desert"
-cooler_wetter_result = "Inaccessible Desert"
+cooler_wetter_result = "Inaccessible Tundra"
 cooler_drier_result  = "Inaccessible Desert"
 {%- else %}
 warmer_wetter_result = "Plains"
@@ -1230,10 +1230,10 @@ clean_pollution_time = 3
 clean_fallout_time   = 3
 animal               = "None"
 {%- if inaccessibleClimates %}
-warmer_wetter_result = "Inaccessible Forest"
-warmer_drier_result  = "Inaccessible Forest"
-cooler_wetter_result = "Inaccessible Forest"
-cooler_drier_result  = "Inaccessible Forest"
+warmer_wetter_result = "Inaccessible Jungle"
+warmer_drier_result  = "Inaccessible Plains"
+cooler_wetter_result = "Inaccessible Swamp"
+cooler_drier_result  = "Inaccessible Tundra"
 {%- else %}
 warmer_wetter_result = "Jungle"
 warmer_drier_result  = "Plains"
@@ -1288,10 +1288,10 @@ clean_pollution_time = 3
 clean_fallout_time   = 3
 animal               = "None"
 {%- if inaccessibleClimates %}
-warmer_wetter_result = "Inaccessible Grassland"
-warmer_drier_result  = "Inaccessible Grassland"
-cooler_wetter_result = "Inaccessible Grassland"
-cooler_drier_result  = "Inaccessible Grassland"
+warmer_wetter_result = "Inaccessible Swamp"
+warmer_drier_result  = "Inaccessible Plains"
+cooler_wetter_result = "Inaccessible Tundra"
+cooler_drier_result  = "Inaccessible Tundra"
 {%- else %}
 warmer_wetter_result = "Swamp"
 warmer_drier_result  = "Plains"
@@ -1402,10 +1402,10 @@ clean_pollution_time = 3
 clean_fallout_time   = 3
 animal               = "None"
 {%- if inaccessibleClimates %}
-warmer_wetter_result = "Inaccessible Jungle"
-warmer_drier_result  = "Inaccessible Jungle"
-cooler_wetter_result = "Inaccessible Jungle"
-cooler_drier_result  = "Inaccessible Jungle"
+warmer_wetter_result = "Inaccessible Swamp"
+warmer_drier_result  = "Inaccessible Desert"
+cooler_wetter_result = "Inaccessible Forest"
+cooler_drier_result  = "Inaccessible Tundra"
 {%- else %}
 warmer_wetter_result = "Swamp"
 warmer_drier_result  = "Desert"
@@ -1520,10 +1520,10 @@ clean_pollution_time = 3
 clean_fallout_time   = 3
 animal               = "None"
 {%- if inaccessibleClimates %}
-warmer_wetter_result = "Inaccessible Plains"
-warmer_drier_result  = "Inaccessible Plains"
-cooler_wetter_result = "Inaccessible Plains"
-cooler_drier_result  = "Inaccessible Plains"
+warmer_wetter_result = "Inaccessible Grassland"
+warmer_drier_result  = "Inaccessible Desert"
+cooler_wetter_result = "Inaccessible Tundra"
+cooler_drier_result  = "Inaccessible Desert"
 {%- else %}
 warmer_wetter_result = "Grassland"
 warmer_drier_result  = "Desert"
@@ -1576,10 +1576,10 @@ clean_pollution_time = 3
 clean_fallout_time   = 3
 animal               = "None"
 {%- if inaccessibleClimates %}
-warmer_wetter_result = "Inaccessible Swamp"
-warmer_drier_result  = "Inaccessible Swamp"
-cooler_wetter_result = "Inaccessible Swamp"
-cooler_drier_result  = "Inaccessible Swamp"
+warmer_wetter_result = "Inaccessible Ocean"
+warmer_drier_result  = "Inaccessible Plains"
+cooler_wetter_result = "Inaccessible Glacier"
+cooler_drier_result  = "Inaccessible Tundra"
 {%- else %}
 warmer_wetter_result = "Ocean"
 warmer_drier_result  = "Plains"
@@ -1635,10 +1635,10 @@ clean_pollution_time = 3
 clean_fallout_time   = 3
 animal               = "None"
 {%- if inaccessibleClimates %}
-warmer_wetter_result = "Inaccessible Tundra"
-warmer_drier_result  = "Inaccessible Tundra"
-cooler_wetter_result = "Inaccessible Tundra"
-cooler_drier_result  = "Inaccessible Tundra"
+warmer_wetter_result = "Inaccessible Swamp"
+warmer_drier_result  = "Inaccessible Plains"
+cooler_wetter_result = "Inaccessible Glacier"
+cooler_drier_result  = "Inaccessible Desert"
 {%- else %}
 warmer_wetter_result = "Swamp"
 warmer_drier_result  = "Plains"


### PR DESCRIPTION
Additionally, GW/NW cause terrain changes in affected tiles even when flipping to inaccessible.

Closes #55 